### PR TITLE
solving apscheduler issue in HASS core 2024.4.0

### DIFF
--- a/custom_components/nano_pk/manifest.json
+++ b/custom_components/nano_pk/manifest.json
@@ -6,6 +6,6 @@
   "domain": "nano_pk",
   "iot_class": "calculated",
   "name": "Hargassner Nano-PK",
-  "requirements": [],
+  "requirements": ["apscheduler"],
   "version": "0.1"
 }


### PR DESCRIPTION
Since HASS core 2024.4.0 the module "apscheduler" can not be loaded and it throws an error message. Adding "apscheduler" to the requirements solves the issue.