### PR TITLE
Make connection handling more robust

### DIFF
--- a/custom_components/nano_pk/hargassner.py
+++ b/custom_components/nano_pk/hargassner.py
@@ -192,12 +192,18 @@ class HargassnerBridge(Entity):
             self._infoLog += "HargassnerBridge._update(): Opening connection...\n"
             try:
                 if self._writer:
-                    self._writer.close()
-                    await self._writer.wait_closed()
+                    try:
+                        self._writer.close()
+                        await self._writer.wait_closed()
+                    except Exception as e:
+                        self._errorLog += "HargassnerBridge.async_update(): Error closing writer (" + repr(e) + ")\n"
+                    finally:
+                        self._reader = None
+                        self._writer = None
                 self._reader, self._writer = await asyncio.wait_for(asyncio.open_connection(self._hostIP, 23), timeout=BRIDGE_TIMEOUT)
                 self._connectionOK = True
-            except Exception:
-                self._errorLog += "HargassnerBridge.async_update(): Error opening connection\n"
+            except Exception as e:
+                self._errorLog += "HargassnerBridge.async_update(): Error opening connection (" + repr(e) + ")\n"
     
     @property
     def name(self) -> str:


### PR DESCRIPTION
This solved #25 for me. Seems that `writer` could not successfully be closed after a `ConnectionResetError`. Now an exception is thrown and `self._reader` and `self._writer` are set to `None`. This way the next attempt to open the connection succeeds.