### PR TITLE
hass.helpers.discovery will stop working in Home Assistant 2024.11

### DIFF
--- a/custom_components/nano_pk/__init__.py
+++ b/custom_components/nano_pk/__init__.py
@@ -1,6 +1,8 @@
 """The Hargassner Nano-PK boiler temperature sensor integration."""
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
+from .hargassner import HargassnerMessageTemplates as hmt
+from homeassistant.helpers import discovery
 
 from .const import (
     DOMAIN,
@@ -40,6 +42,6 @@ async def async_setup(hass, config) -> bool:
     hass.data[DOMAIN][CONF_LANG] = config[DOMAIN].get(CONF_LANG)
     hass.data[DOMAIN][CONF_UNIQUE_ID] = config[DOMAIN].get(CONF_UNIQUE_ID)
 
-    await hass.helpers.discovery.async_load_platform('sensor', DOMAIN, {}, config)
-
+    hass.async_create_task(discovery.async_load_platform(hass, 'sensor', DOMAIN, {}, config))
+                                                         
     return True

--- a/custom_components/nano_pk/sensor.py
+++ b/custom_components/nano_pk/sensor.py
@@ -214,10 +214,10 @@ class HargassnerStateSensor(HargassnerSensor):
         try:
             idxState = int(rawState)
             if not (idxState>=0 and idxState<=12):
-                _LOGGER.warning("HargassnerStateSensor.update(): State index out of bounds.\n")
+                _LOGGER.warning("HargassnerStateSensor.update(): State index out of bounds for sensor: %s. Invalid value: %s\n", self.name, rawState)
                 idxState=0
         except Exception:
-            _LOGGER.warning("HargassnerStateSensor.update(): Invalid state.\n")
+            _LOGGER.warning("HargassnerStateSensor.update(): Invalid state for sensor: %s. Invalid value: %s\n", self.name, rawState)
             idxState = 0
         self._value = self._options[idxState]
         if idxState==6 or idxState==7: self._icon = "mdi:fireplace"  # (transition to) full firing


### PR DESCRIPTION
possible fix for:

hass.helpers.discovery will stop working in Home Assistant 2024.11

log message:
Detected that custom integration 'nano_pk' accesses hass.helpers.discovery. This is deprecated and will stop working in Home Assistant 2024.11, it should be updated to import functions used from discovery directly at custom_components/nano_pk/init.py